### PR TITLE
use $fusioninventory::cronscript_enable in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,11 +15,11 @@ class fusioninventory (
     include
     'fusioninventory::install'
 
-  if ($::cronscript_enable == true){
+  if ($fusioninventory::cronscript_enable == true){
     include   'fusioninventory::cronscript'
   }
 
-  if ($::service_enable == true){
+  if ($fusioninventory::service_enable == true){
     include   'fusioninventory::service'
   }
 


### PR DESCRIPTION
use $fusioninventory::cronscript_enable instead of $::cronscript_enable which does not work when trying to parametrize through hiera (puppetv3). Same goes for $fusioninventory::service_enable.
hiera example below
hieradata/global.yaml
fusioninventory::cronscript_enable: true