### PR TITLE
Adding variable to pass fusioninventory::server_url parameter to temp…

### DIFF
--- a/manifests/cronscript.pp
+++ b/manifests/cronscript.pp
@@ -2,6 +2,7 @@
 #include fusion inventory
 
 class fusioninventory::cronscript inherits fusioninventory {
+  $fusioninventory_server_url = $::fusioninventory::server_url
   file { $::crondest:
     ensure  => 'present',
     owner   => 'root',


### PR DESCRIPTION
…late

When setting fusioninventory::server_url with hiera, parameter does not seem to be passed to fusioninvenroty.erb: @server_url remains http://localhost...
This commit is the first of two commits to enable passing fusioninventory::server_url to template.
Next commit: using new variable in fusioninventory::server_url.