### PR TITLE
Using new variable set in cronscript.pp

### DIFF
--- a/templates/fusioninventory.erb
+++ b/templates/fusioninventory.erb
@@ -16,4 +16,4 @@ HTTPS_PROXY=''
 # To test this script, use --debug
 
 FUSION=$(whereis fusioninventory-agent | cut -d ' ' -f 2)
-$FUSION --server "<%= @server_url %>"
+$FUSION --server "<%= @fusioninventory_server_url %>"


### PR DESCRIPTION
Previous commit in cronscript.pp added a new variable "$fusioninventory_server_url" to actually pass fusioninventory::server_url to this template.
This commit aims at actually using $fusioninventory_server_url parameter.
Maybe there might be a better way to do this but I could not find any documentation on how to fully qualify variable in template like @fusioninventory::server_url. Only way seemed to be using 'scope' function whose purpose is larger than our needs here.
Any comments/improvements welcome.