### PR TITLE
redirect stdout/stderr to /dev/null for cron.daily

### DIFF
--- a/templates/fusioninventory.erb
+++ b/templates/fusioninventory.erb
@@ -16,4 +16,4 @@ HTTPS_PROXY=''
 # To test this script, use --debug
 
 FUSION=$(whereis fusioninventory-agent | cut -d ' ' -f 2)
-$FUSION --server "<%= @fusioninventory_server_url %>"
+$FUSION --server "<%= @fusioninventory_server_url %>" > /dev/null 2>&1


### PR DESCRIPTION
Without redirection alerts might be sent through email to root.
Getting output in cron execution might be due to unexepected errors or situtation justifying such alerts.
This commit aims at making silent fusioninventory-agent cron execution.